### PR TITLE
check if the called function's object is not null

### DIFF
--- a/addons/dynamic_event_manager/src/event_manager.gd
+++ b/addons/dynamic_event_manager/src/event_manager.gd
@@ -46,8 +46,8 @@ func invoke(event: Event) -> void:
 	
 	var listeners = _events[event_type]
 	for i in range(listeners.size() - 1, -1, -1):
-		if listeners[i].get_object() != null:
-			await listeners[i].call(event)
+		var func = listeners[i] as Callable
+		if func.is_null() or !func.is_valid():
+			listeners.remove_at(i)
 		else:
-			listeners.erase(listeners[i])
-
+			await func.call(event)

--- a/addons/dynamic_event_manager/src/event_manager.gd
+++ b/addons/dynamic_event_manager/src/event_manager.gd
@@ -46,4 +46,8 @@ func invoke(event: Event) -> void:
 	
 	var listeners = _events[event_type]
 	for i in range(listeners.size() - 1, -1, -1):
-		await listeners[i].call(event)
+		if listeners[i].get_object() != null:
+			await listeners[i].call(event)
+		else:
+			listeners.erase(listeners[i])
+


### PR DESCRIPTION
calling "get_tree().reload_current_scene()" from inside the listener function made an object in the _events list null. 
Invoke does not check if the function it is calling is not null.
I added a null check on the object of the function.
Other checks on the functions could be added: 

- check if the function itself is null,
- check if the function was added multiple times to the _event list (would be done on add_listener()